### PR TITLE
add custom op schema support for eager mode

### DIFF
--- a/src/eager/ort_backends.cpp
+++ b/src/eager/ort_backends.cpp
@@ -61,11 +61,12 @@ onnxruntime::ORTInvoker& ORTBackendsManager::GetInvoker(const at::Device device)
   auto ep = std::make_unique<onnxruntime::CPUExecutionProvider>(
     onnxruntime::CPUExecutionProviderInfo(false));
 #endif
-
+  
   auto invoker = 
     std::make_unique<onnxruntime::ORTInvoker>(
       std::move(ep),
-      logger_);
+      logger_,
+      custom_op_schema_);
 
   backends_[device_index] = std::move(invoker);
   return *backends_[device_index];

--- a/src/eager/ort_backends.h
+++ b/src/eager/ort_backends.h
@@ -8,6 +8,7 @@
 #include <core/eager/ort_kernel_invoker.h>
 #include <core/graph/schema_registry.h>
 #include "onnx/defs/schema.h"
+#include <core/graph/model.h>
 
 namespace torch_ort {
 namespace eager {

--- a/src/eager/ort_backends.h
+++ b/src/eager/ort_backends.h
@@ -6,6 +6,8 @@
 #include <torch/extension.h>
 #include <core/framework/ml_value.h>
 #include <core/eager/ort_kernel_invoker.h>
+#include <core/graph/schema_registry.h>
+#include "onnx/defs/schema.h"
 
 namespace torch_ort {
 namespace eager {
@@ -20,6 +22,10 @@ public:
 private:
   std::map<at::DeviceIndex, std::unique_ptr<onnxruntime::ORTInvoker>> backends_;
   const onnxruntime::logging::Logger& logger_;
+  //custom op schema registry
+  //TODO: we might want to support load custom op schema on the fly
+  onnxruntime::IOnnxRuntimeOpSchemaRegistryList custom_op_schema_ = {};
+  
 };
 
 ORTBackendsManager& GetORTBackendsManager();

--- a/src/eager/setup.py
+++ b/src/eager/setup.py
@@ -115,7 +115,7 @@ def build_ort():
     '--enable_training',
     '--disable_nccl',
     '--use_mpi', 'true',
-    '--cmake_extra_defines', 'onnxruntime_ENABLE_EAGER_MODE=ON'
+    '--build_eager_mode',
   ]
   if which('ninja'):
     args += ['--cmake_generator', 'Ninja']


### PR DESCRIPTION
add custom op schema support in ort-eager mode, so we can run the custom ops without update ort codebase