### PR TITLE
Add mechanism to build ORTModule's PyTorch CPP extensions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,10 @@ By default, torch-ort depends on PyTorch 1.8.1, ONNX Runtime 1.8 and CUDA 10.2.
     - `pip install ninja`
     - `pip install torch-ort`
 
+4. Run post-installation script for ORTModule
+
+    - `python -m torch_ort.configure`
+
 ### Explicitly install for NVIDIA CUDA 10.2
 
 1. Install CUDA 10.2
@@ -54,6 +58,7 @@ By default, torch-ort depends on PyTorch 1.8.1, ONNX Runtime 1.8 and CUDA 10.2.
     - `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_cu111.html`
     - (or `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu111.html` to use nightly build)
     - `pip install torch-ort`
+    - `python -m torch_ort.configure`
 
 ### Explicitly install for AMD ROCm 4.2
 
@@ -69,6 +74,7 @@ By default, torch-ort depends on PyTorch 1.8.1, ONNX Runtime 1.8 and CUDA 10.2.
     - `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_rocm42.html`
     - (or `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_rocm42.html` to use nightly build)
     - `pip install torch-ort`
+    - `python -m torch_ort.configure`
 
 ### Use torch-ort from nightly build
 #### to use torch-ort from nightly build, replace

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 import setuptools
 from datetime import date
 

--- a/torch_ort/configure/__main__.py
+++ b/torch_ort/configure/__main__.py
@@ -3,4 +3,9 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
-from onnxruntime.training.ortmodule import ORTModule
+def main():
+    from onnxruntime.training.ortmodule.torch_cpp_extensions import install as ortmodule_install
+    ortmodule_install.build_torch_cpp_extensions()
+
+if __name__ == '__main__':
+    main()

--- a/torch_ort/experimental/__init__.py
+++ b/torch_ort/experimental/__init__.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 """Experimental APIs for ORTModule
 
 DO NOT use these APIs for any production code as they can be removed at any time

--- a/torch_ort/experimental/debug.py
+++ b/torch_ort/experimental/debug.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 import os
 from torch_ort import ORTModule
 from onnxruntime.training.ortmodule._logger import LogLevel

--- a/torch_ort/experimental/graph_config.py
+++ b/torch_ort/experimental/graph_config.py
@@ -1,3 +1,8 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
 from enum import Enum
 from onnxruntime.capi._pybind_state import PropagateCastOpsStrategy
 from torch_ort import ORTModule


### PR DESCRIPTION
ORTModule requires PyTorch CPP Extensions to be compiled before being executed.
When users try to use ORTModule before the extensions are compiled, an error with instructions are raised

PyTorch CPP Extensions for ORTModule can be compiled by running:
   python -m torch_ort.configure

Full build environment is needed for this