### PR TITLE
Fix permission denied during docker build

### DIFF
--- a/tools/ci_build/github/azure-pipelines/packaging-pipeline.yml
+++ b/tools/ci_build/github/azure-pipelines/packaging-pipeline.yml
@@ -63,8 +63,8 @@ stages:
 
       # TODO: because the docker image (torchortpackaging) is cached,
       # it may keep failing if the onnxruntime-training or torch installation
-      # that are cached with the image is causing the failure. 
-      # in such case, we need to clearn the cache (onnxruntimebuildcache) 
+      # that are cached with the image is causing the failure.
+      # in such case, we need to clean the cache (onnxruntimebuildcache)
       - task: CmdLine@2
         inputs:
           script: |

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_1
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_1
@@ -7,7 +7,12 @@ FROM nvcr.io/nvidia/cuda:11.1-cudnn8-devel-centos7
 #2. The resulting application is packaged as a Docker container and distributed to users on Docker Hub or the NVIDIA GPU Cloud only.
 #So we use CUDA as the base image then add manylinux on top of it.
 
-#Build manylinux2014 docker image begin
+# Add non-root user
+ARG BUILD_UID=1001
+ARG BUILD_USER=onnxruntimedev
+RUN adduser --uid $BUILD_UID $BUILD_USER
+
+# Build manylinux2014 docker image begin
 ENV AUDITWHEEL_ARCH x86_64
 ENV AUDITWHEEL_PLAT manylinux2014_$AUDITWHEEL_ARCH
 ENV LC_ALL en_US.UTF-8
@@ -23,21 +28,24 @@ RUN bash /manylinux2014_build_scripts/build.sh 8 && rm -r manylinux2014_build_sc
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 
-#Build manylinux2014 docker image end
+# Build manylinux2014 docker image end
 
 ARG PYTHON_VERSION=3.6
 ARG INSTALL_DEPS_EXTRA_ARGS
 
-#Add our own dependencies
+# Add our own dependencies
 ADD scripts /tmp/scripts
 RUN cd /tmp/scripts && \
     /tmp/scripts/install_centos.sh && \
     /tmp/scripts/install_deps.sh -d gpu -p $PYTHON_VERSION $INSTALL_DEPS_EXTRA_ARGS && \
     rm -rf /tmp/scripts
 
-ARG BUILD_UID=1001
-ARG BUILD_USER=onnxruntimedev
-RUN adduser --uid $BUILD_UID $BUILD_USER
+# Make /opt/python symlink (/opt/_internal/cpython-*) folders wriatable for onnxruntimedev user
+RUN chown -fRL onnxruntimedev:onnxruntimedev /opt/python
+RUN chmod 775 -fR /opt/_internal/cpython-*
+
+
+# Switching to no-root user
 WORKDIR /home/$BUILD_USER
 USER $BUILD_USER
 ENV PATH /usr/local/gradle/bin:/usr/local/dotnet:$PATH


### PR DESCRIPTION
ORTModule's torch cpp extension script writes into the python's site-packages/onnxruntime folder, which in this pipeline is owned by root

This PR changes ownership of folder to onnxruntimedev