### PR TITLE
Update eager mode to work against latest PyTorch master

### DIFF
--- a/src/eager/.gitignore
+++ b/src/eager/.gitignore
@@ -1,3 +1,5 @@
 ort_build/
 build/
 ort_aten.g.cpp
+*.so
+*.dylib

--- a/src/eager/opgen/opgen/ast.py
+++ b/src/eager/opgen/opgen/ast.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import io
-from typing import TextIO, List
+from typing import TextIO, List, Union
 from opgen.lexer import Token
 
 class Node(object):
@@ -105,12 +105,16 @@ class ExpressionType(Type):
     self.expression.write(writer)
 
 class ConcreteType(Type):
-  def __init__(self, identifier_token: Token):
+  def __init__(self, identifier_tokens: Union[Token, List[Token]]):
     super().__init__()
-    self.identifier_token = identifier_token
+    if isinstance(identifier_tokens, Token):
+      self.identifier_tokens = [identifier_tokens]
+    else:
+      self.identifier_tokens = identifier_tokens
 
   def write(self, writer: TextIO):
-    writer.write(self.identifier_token.value)
+    for identifier_token in self.identifier_tokens:
+      writer.write(identifier_token.value)
 
 class ConstType(Type):
   def __init__(self, const_token: Token, inner_type: Type):
@@ -176,13 +180,20 @@ class ArrayType(ModifiedType):
     writer.write(self.close_token.value)
 
 class TemplateType(Type):
-  def __init__(self, identifier_token: Token, type_arguments: SyntaxList):
+  def __init__(
+    self,
+    identifier_tokens: Union[Token, List[Token]],
+    type_arguments: SyntaxList):
     super().__init__()
-    self.identifier_token = identifier_token
+    if isinstance(identifier_tokens, Token):
+      self.identifier_tokens = [identifier_tokens]
+    else:
+      self.identifier_tokens = identifier_tokens
     self.type_arguments = type_arguments
 
   def write(self, writer: TextIO):
-    writer.write(self.identifier_token.value)
+    for identifier_token in self.identifier_tokens:
+      writer.write(identifier_token.value)
     self.type_arguments.write(writer)
 
 class TupleMemberType(Type):

--- a/src/eager/opgen/opgen/ast.py
+++ b/src/eager/opgen/opgen/ast.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import sys
 import io
-from typing import TextIO
-from enum import Enum
-from opgen.lexer import TokenKind, Token
+from typing import TextIO, List
+from opgen.lexer import Token
 
 class Node(object):
   def __init__(self):
@@ -35,7 +33,7 @@ class SyntaxListMember(Node):
 
 class SyntaxList(Node):
   open_token: Token
-  members: [SyntaxListMember]
+  members: List[SyntaxListMember]
   close_token: Token
 
   def __init__(self):
@@ -208,10 +206,10 @@ class TupleType(Type):
     self.elements.write(writer)
 
 class AliasInfo(Node):
-  before_set: [str]
-  after_set: [str]
-  contained_types: []
-  tokens: [Token]
+  before_set: List[str]
+  after_set: List[str]
+  contained_types: List[Type]
+  tokens: List[Token]
 
   def __init__(self):
     super().__init__()
@@ -328,7 +326,7 @@ class FunctionDecl(Decl):
     return None
 
 class TranslationUnitDecl(Decl):
-  def __init__(self, decls: [FunctionDecl]):
+  def __init__(self, decls: List[FunctionDecl]):
     super().__init__()
     self.decls = decls
 

--- a/src/eager/opgen/opgen/generator.py
+++ b/src/eager/opgen/opgen/generator.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import TextIO, Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Union
 
 import sys
 import json
@@ -34,7 +34,7 @@ class ONNXAttr:
     self.type = type
 
 class ONNXOpEvalContext:
-  ops: ['ONNXOp']
+  ops: List['ONNXOp']
 
   def __init__(self):
     self.ops = []
@@ -47,8 +47,8 @@ class ONNXOp:
   def __init__(self,
     name: str,
     outputs: int,
-    *inputs: str or Outputs,
-    **attributes: Optional[str or Outputs]):
+    *inputs: Union[str, Outputs],
+    **attributes: Optional[Union[str, Outputs]]):
     self.name = name
     self.outputs = Outputs(outputs)
     self.inputs = inputs
@@ -375,7 +375,7 @@ class ORTGen:
     writer.writeline('}')
     writer.writeline()
 
-  def _get_alias_info(self, torch_type_or_param: ast.Type or ast.ParameterDecl):
+  def _get_alias_info(self, torch_type_or_param: Union[ast.Type, ast.ParameterDecl]):
     if isinstance(torch_type_or_param, ast.ParameterDecl):
       torch_type = torch_type_or_param.parameter_type
     else:

--- a/src/eager/opgen/opgen/lexer.py
+++ b/src/eager/opgen/opgen/lexer.py
@@ -84,6 +84,14 @@ class Token(object):
       self.kind == TokenKind.SINGLE_LINE_COMMENT or
       self.kind == TokenKind.MULTI_LINE_COMMENT)
 
+  def has_trailing_trivia(self, trivia_kind: TokenKind) -> bool:
+    if not self.trailing_trivia:
+      return False
+    for trivia in self.trailing_trivia:
+      if trivia.kind == trivia_kind:
+        return True
+    return False
+
   def __str__(self) -> str:
     return f"{self.location}: [{self.kind}] '{self.value}'"
 

--- a/src/eager/opgen/opgen/lexer.py
+++ b/src/eager/opgen/opgen/lexer.py
@@ -3,6 +3,7 @@
 
 from enum import Enum
 from abc import ABC
+from typing import List, Optional, Union, Tuple
 
 class SourceLocation(object):
   def __init__(self,
@@ -63,11 +64,11 @@ class TokenKind(Enum):
 
 class Token(object):
   def __init__(self,
-    location: SourceLocation,
+    location: Union[SourceLocation, Tuple[int, int, int]],
     kind: TokenKind,
     value: str,
-    leading_trivia = None,
-    trailing_trivia = None):
+    leading_trivia: Optional[List["Token"]] = None,
+    trailing_trivia: Optional[List["Token"]] = None):
     if isinstance(location, tuple) or isinstance(location, list):
       location = SourceLocation(location[0], location[1], location[2])
 
@@ -143,7 +144,7 @@ class StringReader(Reader):
 class Lexer(object):
   _peek: str
   _next_token: Token
-  _first_token_leading_trivia: [Token]
+  _first_token_leading_trivia: List[Token]
 
   char_to_token_kind = {
     '(': TokenKind.OPEN_PAREN,
@@ -210,8 +211,8 @@ class Lexer(object):
     attached to it.
     """
     token: Token
-    leading_trivia: [Token] = None
-    trailing_trivia: [Token] = None
+    leading_trivia: Optional[List[Token]] = None
+    trailing_trivia: Optional[List[Token]] = None
 
     while True:
       token = self._lex_core()

--- a/src/eager/opgen/opgen/parser.py
+++ b/src/eager/opgen/opgen/parser.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from enum import Enum
 from opgen.lexer import *
 from opgen.ast import *
+from typing import List, Tuple, Union, Optional
 
 class UnexpectedTokenError(RuntimeError):
   def __init__(self, expected: TokenKind, actual: Token):
@@ -16,9 +16,9 @@ class ExpectedSyntaxError(RuntimeError):
     super().__init__(f"expected {expected}; actual {actual}")
 
 class ParserBase(object):
-  _peek_queue: [Token]
+  _peek_queue: List[Token]
 
-  def __init__(self, lexer: Lexer or Reader):
+  def __init__(self, lexer: Union[Lexer, Reader]):
     self._own_lexer = False
     if isinstance(lexer, Reader):
       self._own_lexer = True
@@ -181,7 +181,7 @@ class CPPParser(ParserBase):
     return self.parse_type()
 
 class TorchParser(ParserBase):
-  def __init__(self, lexer: Lexer or Reader):
+  def __init__(self, lexer: Union[Lexer, Reader]):
     super().__init__(lexer)
     self._next_anonymous_alias_id = 0
 
@@ -216,7 +216,7 @@ class TorchParser(ParserBase):
       parsed_type = AliasInfoType(parsed_type, alias_info)
     return parsed_type
 
-  def _parse_type_and_alias(self) -> (Type, AliasInfo):
+  def _parse_type_and_alias(self) -> Tuple[Type, AliasInfo]:
     parsed_type: Type = None
     alias_info: AliasInfo = None
 
@@ -292,7 +292,7 @@ class TorchParser(ParserBase):
   def _parse_torch_alias_info(self) -> AliasInfo:
     alias_info = AliasInfo()
 
-    def parse_set(alias_set: [str]):
+    def parse_set(alias_set: List[str]):
       while True:
         if self._peek_token(TokenKind.MUL):
           alias_info.tokens.append(self._read_token())

--- a/src/eager/opgen/opgen/writer.py
+++ b/src/eager/opgen/opgen/writer.py
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import TextIO
+from typing import TextIO, List
 
 class SourceWriter:
   _writer: TextIO
   _indent_str: str
   _indent_depth: int
   _needs_indent: bool
-  _namespaces: [str]
+  _namespaces: List[str]
 
   def __init__(self, base_writer: TextIO, indent_str: str = '  '):
     self._writer = base_writer


### PR DESCRIPTION
There are four commits in this PR which are best reviewed indepenently to ease readability.

1. Bump to latest PyTorch.
2. .gitignore binary artifacts.
3. Fix various type hints in the generator code for better IntelliSense.
4. Support parsing qualified (::) identifiers now showing up in RegistrationDeclarations.h (e.g. `::std::tuple` vs `tuple` now).

Depends on #46 as well.