### PR TITLE
Simplify install instructions.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,13 +10,13 @@ This repository contains the source code for the package as well as instructions
 
 You need a machine with at least one NVIDIA or AMD GPU to run ONNX Runtime for PyTorch.
 
-You can install and run torch-ort in your local environment, or with Docker.
+You can install and run torch-ort in your local environment, or with Docker (see instructions in the [Docker folder](docker/README.md)).
 
-## Run in a Python environment
+## Install in a local Python environment
 
 ### Default dependencies
 
-By default, torch-ort depends on PyTorch 1.8.1, ONNX Runtime 1.8 and CUDA 10.2.
+By default, torch-ort depends on PyTorch 1.9.0, ONNX Runtime 1.8.1 and CUDA 10.2.
 
 1. Install CUDA 10.2
 
@@ -31,110 +31,21 @@ By default, torch-ort depends on PyTorch 1.8.1, ONNX Runtime 1.8 and CUDA 10.2.
 
     - `python -m torch_ort.configure`
 
-### Explicitly install for NVIDIA CUDA 10.2
-
-1. Install CUDA 10.2
-
-2. Install CuDNN 7.6
-
-3. Install torch-ort and dependencies
-
-    - `pip install ninja`
-    - `pip install torch==1.8.1`
-    - `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_cu102.html`
-    - (or `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu102.html` to use nightly build)
-    - `pip install torch-ort`
-
-### Explicitly install for NVIDIA CUDA 11.1
-
-1. Install CUDA 11.1
-
-2. Install CuDNN 8.0
-
-3. Install torch-ort and dependencies
-
-    - `pip install ninja`
-    - `pip install torch==1.8.1`
-    - `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_cu111.html`
-    - (or `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_nightly_cu111.html` to use nightly build)
-    - `pip install torch-ort`
-    - `python -m torch_ort.configure`
-
-### Explicitly install for AMD ROCm 4.2 (preview)
-
-1. Install ROCm 4.2 base package ([instructions](https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html))
-
-2. Install ROCm 4.2 libraries ([instructions](https://rocmdocs.amd.com/en/latest/Installation_Guide/Software-Stack-for-AMD-GPU.html#machine-learning-and-high-performance-computing-software-stack-for-amd-gpu-v4-1))
-
-3. Install ROCm 4.2 RCCL ([instructions](https://github.com/ROCmSoftwarePlatform/rccl/tree/rocm-4.2.0))
-
-5. Install torch-ort and dependencies
-    - `pip install ninja`
-    - `pip install --pre torch -f https://download.pytorch.org/whl/rocm4.2/torch_stable.html`
-    - `pip install --pre onnxruntime-training -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_torch190.rocm42.html`
-    - `pip install --pre torch-ort -f 'https://onnxruntimepackages.blob.core.windows.net/$web/torch_ort_nightly.html'`
-    - `python -m torch_ort.configure`
-
-### Use torch-ort from nightly build
-#### to use torch-ort from nightly build, replace
-   - `pip install torch-ort`
-
-with
-   - `pip install -U --pre torch-ort -f https://onnxruntimepackages.z14.web.core.windows.net/torch_ort_nightly.html`
-
-## Run using Docker 
-
-### On NVIDIA CUDA 11.1
-
-The [docker](docker) directory contains dockerfiles for the NVIDIA CUDA 11.1 configuration.
-
-- [docker/Dockerfile.ort-torch190-onnxruntime181-cu111-cudnn8-devel-ubuntu18.04](docker/Dockerfile.ort-torch190-onnxruntime181-cu111-cudnn8-devel-ubuntu18.04)
-
-1. Build the docker image
-
-    `docker build -f Dockerfile.ort-torch190-onnxruntime181-cu111-cudnn8-devel-ubuntu18.04 -t ort.cu111 .`
-
-2. Run the docker container using the image you have just built
-
-    `docker run -it --gpus all --name my-experiments ort.cu111:latest /bin/bash`
-
-###  On AMD ROCm 4.2 (preview)
-
-The [docker](docker) directory contains dockerfiles for the AMD ROCm 4.2 configuration.
-
-- [docker/Dockerfile.ort-torch181-onnxruntime-stable-rocm4.2-ubuntu18.04](docker/Dockerfile.ort-torch181-onnxruntime-stable-rocm4.2-ubuntu18.04)
-
-1. Build the docker image
-
-    `docker build -f Dockerfile.ort-torch181-onnxruntime-stable-rocm4.2-ubuntu18.04 -t ort.rocm42 .`
-
-2. Run the docker container using the image you have just built
-
-    ```
-    docker run -it --rm \
-      --privileged \
-      --device=/dev/kfd \
-      --device=/dev/dri \
-      --group-add video \
-      --cap-add=SYS_PTRACE \
-      --security-opt seccomp=unconfined \
-      --name my-experiments \
-      ort.rocm42:latest /bin/bash
-    ```
+Get install instructions for other combinations in the `Get Started Easily` section at <https://www.onnxruntime.ai/> under the `Optimize Training` tab.
 
 ## Test your installation
 
 1. Clone this repo
 
-- `git clone git@github.com:pytorch/ort.git`
+    - `git clone git@github.com:pytorch/ort.git`
 
 2. Install extra dependencies
 
-- `pip install wget pandas sklearn transformers`
+    - `pip install wget pandas sklearn transformers`
 
 3. Run the training script
 
-- `python ./ort/tests/bert_for_sequence_classification.py`
+    - `python ./ort/tests/bert_for_sequence_classification.py`
 
 ## Add ONNX Runtime for PyTorch to your PyTorch training script
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+# Accelerate PyTorch models with ONNX Runtime
+
+Instructions below assume you are entering commands from the `docker` folder in this repository. Docker files available for CUDA and ROCm configurations.
+
+## Run using Docker
+
+### On NVIDIA CUDA 11.1
+
+1. Build the docker image
+
+    `docker build -f Dockerfile.ort-torch190-onnxruntime181-cu111-cudnn8-devel-ubuntu18.04 -t ort.cu111 .`
+
+2. Run the docker container using the image you have just built
+
+    `docker run -it --gpus all --name my-experiments ort.cu111:latest /bin/bash`
+
+### On AMD ROCm 4.2 (preview)
+
+1. Build the docker image
+
+    `docker build -f Dockerfile.ort-torch181-onnxruntime-stable-rocm4.2-ubuntu18.04 -t ort.rocm42 .`
+
+2. Run the docker container using the image you have just built
+
+    ```bash
+    docker run -it --rm \
+      --privileged \
+      --device=/dev/kfd \
+      --device=/dev/dri \
+      --group-add video \
+      --cap-add=SYS_PTRACE \
+      --security-opt seccomp=unconfined \
+      --name my-experiments \
+      ort.rocm42:latest /bin/bash
+    ```
+
+## Test your installation
+
+Follow the same instructions to test the local Python installation, available from the main [README](../Readme.md).


### PR DESCRIPTION
Move Docker instructions to README under the Docker folder.
Remove instructions for "many configurations", and point to https://www.onnxruntime.ai/ instead.