### PR TITLE
Custom operator for transformer decoder 

### DIFF
--- a/src/eager/msnpu_ops.cpp
+++ b/src/eager/msnpu_ops.cpp
@@ -1,0 +1,106 @@
+#include "msnpu_ops.h"
+#include "ort_aten.h"
+#include "ort_backends.h"
+
+namespace torch_ort {
+namespace eager {
+namespace msnpu {
+
+std::vector<at::Tensor> transformerdecoder(
+    int64_t padded_hidden_size, int64_t head_size, float soft_dropout_prob,
+    int64_t soft_dropout_seed, float dense_dropout_prob,
+    int64_t dense_dropout_seed, float mlp_dropout_prob,
+    int64_t mlp_dropout_seed, float epsilon,
+    const torch::Tensor& embeddings_post_dropout,
+    const torch::Tensor& normalization_1_w,
+    const torch::Tensor& normalization_1_b, const torch::Tensor& query_w,
+    const torch::Tensor& query_b, const torch::Tensor& key_w,
+    const torch::Tensor& key_b, const torch::Tensor& value_w,
+    const torch::Tensor& value_b, const torch::Tensor& attention_mask,
+    const torch::Tensor& project_w, const torch::Tensor& project_b,
+    const torch::Tensor& FFN1_w, const torch::Tensor& FFN1_b,
+    const torch::Tensor& FFN2_w, const torch::Tensor& FFN2_b,
+    const torch::Tensor& normalization_2_w,
+    const torch::Tensor& normalization_2_b, const torch::Tensor& pad_values) {
+
+  auto& invoker = GetORTInvoker(embeddings_post_dropout.device());
+  constexpr size_t num_outputs = 18;
+  constexpr size_t num_attrs = 8;
+  const  std::string ort_op_name = "TransformerDecoder";
+
+  // Create ORT attributes
+  onnxruntime::NodeAttributes attrs(num_attrs);
+  attrs["paddedHiddenSize"] = create_ort_attribute(
+      "paddedHiddenSize", padded_hidden_size, at::ScalarType::Long);
+  attrs["headSize"] =
+      create_ort_attribute("headSize", head_size, at::ScalarType::Long);
+  attrs["softDropoutProb"] = create_ort_attribute(
+      "softDropoutProb", soft_dropout_prob, at::ScalarType::Float);
+  attrs["softDropoutSeed"] = create_ort_attribute(
+      "softDropoutSeed", soft_dropout_seed, at::ScalarType::Long);
+  attrs["denseDropoutProb"] = create_ort_attribute(
+      "denseDropoutProb", dense_dropout_prob, at::ScalarType::Float);
+  attrs["denseDropoutSeed"] = create_ort_attribute(
+      "denseDropoutSeed", dense_dropout_seed, at::ScalarType::Long);
+  attrs["denseDropoutProb"] = create_ort_attribute(
+      "denseDropoutProb", mlp_dropout_prob, at::ScalarType::Float);
+  attrs["mlpDropoutProb"] = create_ort_attribute(
+      "mlpDropoutProb", dense_dropout_seed, at::ScalarType::Float);
+  attrs["mlpDropoutSeed"] = create_ort_attribute(
+      "mlpDropoutSeed", mlp_dropout_seed, at::ScalarType::Long);
+  attrs["epsilon"] =
+      create_ort_attribute("epsilon", epsilon, at::ScalarType::Float);
+
+  // Create ORTValues for input tensors
+  auto ort_in_embeddings_post_dropout =
+      create_ort_value(invoker, embeddings_post_dropout);
+  auto ort_in_normalization_1_w = create_ort_value(invoker, normalization_1_w);
+  auto ort_in_normalization_1_b = create_ort_value(invoker, normalization_1_b);
+  auto ort_in_query_w = create_ort_value(invoker, query_w);
+  auto ort_in_query_b = create_ort_value(invoker, query_b);
+  auto ort_in_key_w = create_ort_value(invoker, key_w);
+  auto ort_in_key_b = create_ort_value(invoker, key_b);
+  auto ort_in_value_w = create_ort_value(invoker, value_w);
+  auto ort_in_value_b = create_ort_value(invoker, value_b);
+  auto ort_in_attention_mask = create_ort_value(invoker, attention_mask);
+  auto ort_in_project_w = create_ort_value(invoker, project_w);
+  auto ort_in_project_b = create_ort_value(invoker, project_b);
+  auto ort_in_FFN1_w = create_ort_value(invoker, FFN1_w);
+  auto ort_in_FFN1_b = create_ort_value(invoker, FFN1_b);
+  auto ort_in_FFN2_w = create_ort_value(invoker, FFN2_w);
+  auto ort_in_FFN2_b = create_ort_value(invoker, FFN2_b);
+  auto ort_in_normalization_2_w = create_ort_value(invoker, normalization_2_w);
+  auto ort_in_normalization_2_b = create_ort_value(invoker, normalization_2_b);
+  auto ort_in_pad_values = create_ort_value(invoker, pad_values);
+
+  // Create ORTValues for output tensors.
+  std::vector<OrtValue> ort_outputs(num_outputs);
+
+  // Invoke the transformer decoder command on the ORT device
+  auto status = invoker.Invoke(
+      ort_op_name,
+      {ort_in_embeddings_post_dropout, ort_in_normalization_1_w,
+       ort_in_normalization_1_b, ort_in_query_w, ort_in_query_b, ort_in_key_w,
+       ort_in_key_b, ort_in_value_w, ort_in_value_b, ort_in_attention_mask,
+       ort_in_project_w, ort_in_project_b, ort_in_FFN1_w, ort_in_FFN1_b,
+       ort_in_FFN2_w, ort_in_FFN2_b, ort_in_normalization_2_w,
+       ort_in_normalization_2_b, ort_in_pad_values},
+      ort_outputs, &attrs, onnxruntime::kMSDomain);
+
+  if (!status.IsOK()) {
+    throw std::runtime_error("ORT returned a failure status: " +
+                             status.ErrorMessage());
+  }
+
+  // Transform outputs into torch tensors
+  std::vector<at::Tensor> outputs(num_outputs);
+  for (size_t i = 0; i < num_outputs; i++) {
+    outputs[i] = aten_tensor_from_ort(std::move(ort_outputs[i]),
+                                      embeddings_post_dropout.options());
+  }
+
+  return outputs;
+}
+} // namespace msnpu
+} // namespace eager
+} // namespace torch_ort

--- a/src/eager/msnpu_ops.h
+++ b/src/eager/msnpu_ops.h
@@ -1,0 +1,28 @@
+#include <torch/extension.h>
+#include <vector>
+
+namespace torch_ort {
+namespace eager {
+namespace msnpu {
+
+static const char * const TransformerDecoderName = "transformerdecoder";
+
+std::vector<at::Tensor> transformerdecoder(
+    int64_t padded_hidden_size, int64_t head_size, float soft_dropout_prob,
+    int64_t soft_dropout_seed, float dense_dropout_prob,
+    int64_t dense_dropout_seed, float mlp_dropout_prob,
+    int64_t mlp_dropout_seed, float epsilon,
+    const torch::Tensor& embeddings_post_dropout,
+    const torch::Tensor& normalization_1_w,
+    const torch::Tensor& normalization_1_b, const torch::Tensor &query_w,
+    const torch::Tensor& query_b, const torch::Tensor &key_w,
+    const torch::Tensor& key_b, const torch::Tensor &value_w,
+    const torch::Tensor& value_b, const torch::Tensor &attention_mask,
+    const torch::Tensor& project_w, const torch::Tensor &project_b,
+    const torch::Tensor& FFN1_w, const torch::Tensor &FFN1_b,
+    const torch::Tensor& FFN2_w, const torch::Tensor &FFN2_b,
+    const torch::Tensor& normalization_2_w,
+    const torch::Tensor& normalization_2_b, const torch::Tensor &pad_values);
+}
+} // namespace eager
+} // namespace torch_ort

--- a/src/eager/ort_backends.cpp
+++ b/src/eager/ort_backends.cpp
@@ -3,6 +3,7 @@
 
 #include <core/providers/cpu/cpu_execution_provider.h>
 #include <core/common/logging/sinks/clog_sink.h>
+#include <core/framework/customregistry.h>
 #include "ort_backends.h"
 #include "ort_log.h"
 
@@ -10,6 +11,69 @@
   namespace onnxruntime {
     std::unique_ptr<onnxruntime::IExecutionProvider> CreateMSNPU_ExecutionProvider();
   }
+
+// Arbitrary
+static constexpr int BaselineOpsetVersion = 1;
+
+// This must be larger than BaselineOpsetVersion
+static constexpr int OpsetVersion = 2;
+
+static onnx::OpSchema CreateTransformerDecoderSchema() {
+  onnx::OpSchema schema("TransformerDecoder", "" /* arbitrary filename */, 0 /* arbitrary line number */);
+  schema.SetDomain(onnxruntime::kMSDomain);
+  schema.SinceVersion(BaselineOpsetVersion);
+  schema.SetDoc("Single Layer of Custom Transformer TNLG");
+  schema.Input(0, "X_0", "input embeddings", "T");
+  schema.Input(1, "X_1", "normalization weight", "T");
+  schema.Input(2, "X_2", "normalization bias", "T");
+  schema.Input(3, "X_3", "query weight", "T");
+  schema.Input(4, "X_4", "query bias", "T");
+  schema.Input(5, "X_5", "key weight", "T");
+  schema.Input(6, "X_6", "key bias", "T");
+  schema.Input(7, "X_7", "value weight", "T");
+  schema.Input(8, "X_8", "value bias", "T");
+  schema.Input(9, "X_9", "attention mask", "T");
+  schema.Input(10, "X_10", "project weight", "T");
+  schema.Input(11, "X_11", "project bias", "T");
+  schema.Input(12, "X_12", "feedforward network weight", "T");
+  schema.Input(13, "X_13", "feedforward network bias", "T");
+  schema.Input(14, "X_14", "feedforward network weight", "T");
+  schema.Input(15, "X_15", "feedforward network bias", "T");
+  schema.Input(16, "X_16", "normalization weight", "T");
+  schema.Input(17, "X_17", "normalizaton bias", "T");
+  schema.Input(18, "X_18", "pad values", "T");
+  schema.Output(0, "Y_0", "layer norm", "T");
+  schema.Output(1, "Y_1", "std inv DMemAddr", "T");
+  schema.Output(2, "Y_2", "shift DMemAddr", "T");
+  schema.Output(3, "Y_3", "query DMem", "T");
+  schema.Output(4, "Y_4", "key DMem", "T");
+  schema.Output(5, "Y_5", "value DMem", "T");
+  schema.Output(6, "Y_6", "softmax DMem", "T");
+  schema.Output(7, "Y_7", "soft dropout DMem", "T");
+  schema.Output(8, "Y_8", "soft dropout mask DMem", "T");
+  schema.Output(9, "Y_9", "soft DMem", "T");
+  schema.Output(10, "Y_10", "dense dropout mask DMem", "T");
+  schema.Output(11, "Y_11", "post selfattention layer norm", "T");
+  schema.Output(12, "Y_12", "normalization std inv DMemAddr", "T");
+  schema.Output(13, "Y_13", "normalization shift DMemAddr", "T");
+  schema.Output(14, "Y_14", "multilayer perceptron dense", "T");
+  schema.Output(15, "Y_15", "multilayer perceptron gelu", "T");
+  schema.Output(16, "Y_16", "multilayer perceptron dropout mask", "T");
+  schema.Output(17, "Y_17", "residual connection", "T");
+  schema.Attr("softDropoutProb", "softmax dropout probability", ONNX_NAMESPACE::AttributeProto::FLOAT, 0.0f);
+  schema.Attr("denseDropoutProb", "dense dropout probability", ONNX_NAMESPACE::AttributeProto::FLOAT, 0.0f);
+  schema.Attr("mlpDropoutProb", "MLP dropout probability", ONNX_NAMESPACE::AttributeProto::FLOAT, 0.0f);
+  schema.Attr("paddedHiddenSize", "padded hidden size", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(1024));
+  schema.Attr("headSize", "head size", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(64));
+  schema.Attr("softDropoutSeed", "softmax dropout seed", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(111));
+  schema.Attr("denseDropoutSeed", "dense layer dropout seed", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(222));
+  schema.Attr("mlpDropoutSeed", "mlp dropout seed", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(333));
+  schema.Attr("epsilon", "epsilon value", ONNX_NAMESPACE::AttributeProto::FLOAT, 1e-5f);
+  schema.Attr("numHeads", "number of heads", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(8));
+  schema.Attr("hiddenSize", "hidden size", ONNX_NAMESPACE::AttributeProto::INT, static_cast<int64_t>(512));
+  schema.TypeConstraint("T", {"tensor(float)"}, "Constrain input and output types to float or bfloat16 tensors.");
+  return schema;
+}
 #endif
 
 //use the environment from python module
@@ -52,6 +116,16 @@ onnxruntime::ORTInvoker& ORTBackendsManager::GetInvoker(const at::Device device)
 
 #ifdef USE_MSNPU
   auto ep = onnxruntime::CreateMSNPU_ExecutionProvider();
+
+  // Register schemas for MSNPU ops
+  onnxruntime::CustomRegistry customRegistry;
+  std::vector<onnx::OpSchema> schemas{CreateTransformerDecoderSchema()};
+  auto status = customRegistry.RegisterOpSet(schemas, onnxruntime::kMSDomain, BaselineOpsetVersion, OpsetVersion);
+  if(!status.IsOK())
+  {
+      throw std::runtime_error("ORT return failure status:" + status.ErrorMessage());
+  }
+  custom_op_schema_.push_back(customRegistry.GetOpschemaRegistry());
 #else
   auto ep = std::make_unique<onnxruntime::CPUExecutionProvider>(
     onnxruntime::CPUExecutionProviderInfo(false));

--- a/src/eager/ort_eager.cpp
+++ b/src/eager/ort_eager.cpp
@@ -9,6 +9,7 @@
 #include "orttraining/core/framework/ortmodule_graph_builder.h"
 #include "python/onnxruntime_pybind_state_common.h"
 #include "core/dlpack/dlpack_python.h"
+#include "msnpu_ops.h"
 
 namespace onnxruntime{
 namespace python{
@@ -65,6 +66,11 @@ PYBIND11_MODULE(torch_ort, torch_ort_module) {
   torch_ort_module.def("ort_from_dlpack", [](py::object dlpack_tensor) {
     return ORTTensor_FromDLPack(dlpack_tensor);
   });
+
+#ifdef USE_MSNPU
+    auto msnpu_module = torch_ort_module.def_submodule("msnpu");
+    msnpu_module.def(torch_ort::eager::msnpu::TransformerDecoderName, &torch_ort::eager::msnpu::transformerdecoder);
+#endif
 }
 
 } // namespace eager

--- a/src/eager/setup.py
+++ b/src/eager/setup.py
@@ -71,6 +71,7 @@ ort_include_dirs = [
   os.path.join(ort_src_dir, 'cmake', 'external', 'mp11', 'include'),
   os.path.join(ort_src_dir, 'cmake', 'external', 'optional-lite', 'include'),
   os.path.join(ort_src_dir, 'cmake', 'external', 'dlpack', 'include'),
+  os.path.join(ort_src_dir, 'cmake', 'external', 'optional-lite', 'include'),
   os.path.join(ort_build_dir, 'external', 'onnx'),
   np.get_include()
 ]


### PR DESCRIPTION
1. Defines a custom operator for the transformer decoder operation - this extension is only enabled if the `USE_MSNPU` compiler flag is defined. 
2. Registers the transformer decoder schema with onnxruntime
3. Adds `optional-lite` to the include path since it is needed by `customregistry.h`
4. Testing: `torch_ort` compiles successfully on a local Ubuntu 20.04 machine and has been tested using a python script in an external repository on a custom execution provider.