### PR TITLE
eager: bump PyTorch to latest master

### DIFF
--- a/src/eager/ort_tensor.h
+++ b/src/eager/ort_tensor.h
@@ -13,10 +13,7 @@ class ORTTensorImpl final : public c10::TensorImpl {
  public:
   explicit ORTTensorImpl(OrtValue tensor, const at::TensorOptions& options)
     : c10::TensorImpl(
-        c10::DispatchKeySet {
-          c10::DispatchKey::ORT,
-          c10::DispatchKey::AutogradORT
-        },
+        c10::DispatchKeySet{c10::DispatchKey::ORT},
         options.dtype(),
         options.device()) {
     set_tensor(tensor);


### PR DESCRIPTION
This updates PyTorch to point to the updated commit where we are [repurposing MSNPU as ORT](https://github.com/pytorch/pytorch/pull/58248).