### PR TITLE
Separate samples and test files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ By default, torch-ort depends on PyTorch 1.9.0, ONNX Runtime 1.8.1 and CUDA 10.2
 
 Get install instructions for other combinations in the `Get Started Easily` section at <https://www.onnxruntime.ai/> under the `Optimize Training` tab.
 
-## Test your installation
+## Verify your installation
 
 1. Clone this repo
 

--- a/tests/bert_for_sequence_classification.py
+++ b/tests/bert_for_sequence_classification.py
@@ -16,7 +16,7 @@ import time
 import datetime
 
 import onnxruntime
-from torch_ort import ORTModule, DebugOptions
+from torch_ort import ORTModule
 
 def train(model, optimizer, scheduler, train_dataloader, epoch, device, args):
     # ========================================
@@ -375,9 +375,7 @@ def main():
     )
 
     if not args.pytorch_only:
-        debug_options = DebugOptions(save_onnx=False, onnx_prefix='BertForSequenceClassification')
-
-        model = ORTModule(model, debug_options=debug_options)
+        model = ORTModule(model)
 
     # Tell pytorch to run this model on the GPU.
     if torch.cuda.is_available() and not args.no_cuda:


### PR DESCRIPTION
Newly updated test file `bert_for_sequence_classification.py` breaks compatibility with `torch_ort 1.8.1`. Since our documentation uses the test file as reference for a sample run, it would result in an error.

This pull request separates out the test file (with the updated version) and the sample file (which is compatible with the current release of `torch_ort`).

This is in reference to issue created #68 