### PR TITLE
Pass in nightly as an explicit variable to the pipeline template

### DIFF
--- a/tools/ci_build/github/azure-pipelines/packaging-pipeline-nightly.yml
+++ b/tools/ci_build/github/azure-pipelines/packaging-pipeline-nightly.yml
@@ -29,6 +29,9 @@ stages:
             PublicDockerFile: 'docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04'
             UploadWheel: 'yes'
 
+      variables:
+        BuildType: 'nightly'
+
       steps:
       - checkout: self
         clean: true
@@ -39,7 +42,7 @@ stages:
           PythonVersion: $(PythonVersion)
           PublicDockerFile: $(PublicDockerFile)
           UploadWheel: $(UploadWheel)
-          BuildType: 'nightly'
+          BuildType: $(BuildType)
 
       - template: templates/component-governance-component-detection-steps.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/packaging-pipeline-stable.yml
+++ b/tools/ci_build/github/azure-pipelines/packaging-pipeline-stable.yml
@@ -26,6 +26,9 @@ stages:
             PythonVersion: '3.8'
             PublicDockerFile: 'docker/Dockerfile.ort-default-stable-torch190-onnxruntime181-cu102-cudnn7-devel-ubuntu18.04'
 
+      variables:
+        BuildType: 'stable'
+
       steps:
       - checkout: self
         clean: true
@@ -36,7 +39,7 @@ stages:
           PythonVersion: $(PythonVersion)
           PublicDockerFile: $(PublicDockerFile)
           UploadWheel: $(UploadWheel)
-          BuildType: 'stable'
+          BuildType: $(BuildType)
 
       - template: templates/component-governance-component-detection-steps.yml
         parameters:

--- a/tools/ci_build/github/azure-pipelines/templates/packaging-pipeline-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/packaging-pipeline-steps.yml
@@ -10,6 +10,7 @@ parameters:
   default: ""
 - name: BuildType
   type: string
+  default: ""
 
 steps:
 


### PR DESCRIPTION
Currently, the pipeline is not able to evaluate that the build type is nightly during execution of the pipeline condition to upload the wheel. So, this pull request explicitly specifies the build type as a variable.