### PR TITLE
decouple torch version from onnxruntime package

### DIFF
--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -22,7 +22,7 @@ RUN pip install onnx ninja
 RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch190.cu102.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -22,7 +22,7 @@ RUN pip install onnx ninja
 RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch190.cu111.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch181.cu102.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch181.cu111.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch190.cu102.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_torch190.cu111.html
+RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install onnxruntime-training==1.9.0 -f https://download.onnxruntime.ai/onnxruntime_stable_torch190.cu102.html
+RUN pip install onnxruntime-training==1.9.0 -f https://download.onnxruntime.ai/onnxruntime_stable_cu102.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/docker/Dockerfile.ort-torch190-onnxruntime190-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime190-cu111-cudnn8-devel-ubuntu18.04
@@ -26,7 +26,7 @@ RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TORCHVISION_VERSION}+${TORCH_CUDA_VERSION} -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install onnxruntime-training==1.9.0 -f https://download.onnxruntime.ai/onnxruntime_stable_torch190.cu111.html
+RUN pip install onnxruntime-training==1.9.0 -f https://download.onnxruntime.ai/onnxruntime_stable_cu111.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure


### PR DESCRIPTION
onnxruntime-training packages are not associated with torch version. Update docker files to reflect this fact.