### PR TITLE
Specify CUDA target architectures for CUDA dockerfiles due to no GPU/driver presence.

### DIFF
--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -25,8 +25,8 @@ RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu102/to
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -25,7 +25,8 @@ RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu102/to
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -25,8 +25,8 @@ RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu111/to
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch-and-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -25,7 +25,8 @@ RUN pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu111/to
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,8 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,7 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -29,8 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -29,7 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,8 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,7 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -29,8 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
-ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
+ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+RUN python -m torch_ort.configure
 
 WORKDIR /workspace
 

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -29,7 +29,8 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu111.html
 
 RUN pip install torch-ort
-RUN python -m torch_ort.configure
+RUN mkdir -p /scripts && echo "python -m torch_ort.configure; /bin/bash" > /scripts/bootstrap.sh
+ENTRYPOINT ["/bin/bash", "/scripts/bootstrap.sh"]
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Torch is getting index out of range error during CUDA extension compilation when device count = 0. Does not appear to be an issue for ROCm extension.