### PR TITLE
update arches for Cuda 10.2 - Remove Compute versions >=8 which are not supported by Cuda 10.2.

### DIFF
--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,7 +29,7 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+ENV TORCH_CUDA_ARCH_LIST="5.0 5.2 6.0 6.1 7.0 7.5+PTX"
 RUN python -m torch_ort.configure
 
 WORKDIR /workspace

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -29,7 +29,7 @@ RUN pip install torch==${TORCH_VERSION}+${TORCH_CUDA_VERSION} torchvision==${TOR
 RUN pip install --pre onnxruntime-training -f https://download.onnxruntime.ai/onnxruntime_nightly_cu102.html
 
 RUN pip install torch-ort
-ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX"
+ENV TORCH_CUDA_ARCH_LIST="5.0 5.2 6.0 6.1 7.0 7.5+PTX"
 RUN python -m torch_ort.configure
 
 WORKDIR /workspace


### PR DESCRIPTION
Remove Compute versions >=8 which are not supported by Cuda 10.2.