### PR TITLE
Update nvidia docker images with new gpg keys and update the blob upload logic

### DIFF
--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu102
 ARG TORCH_VERSION=1.8.1

--- a/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch181-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu111
 ARG TORCH_VERSION=1.8.1

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu102-cudnn7-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu102
 ARG TORCH_VERSION=1.9.0

--- a/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
+++ b/docker/Dockerfile.ort-torch190-onnxruntime-nightly-cu111-cudnn8-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu111
 ARG TORCH_VERSION=1.9.0

--- a/tools/ci_build/github/azure-pipelines/templates/packaging-pipeline-steps.yml
+++ b/tools/ci_build/github/azure-pipelines/templates/packaging-pipeline-steps.yml
@@ -86,7 +86,7 @@ steps:
     scriptType: 'bash'
     scriptLocation: 'inlineScript'
     inlineScript: |
-      python3 -m pip install azure-storage-blob==2.1.0 && \
+      python3 -m pip install azure-storage-blob && \
       files=($(Build.SourcesDirectory)/dist/*.whl) && \
       echo ${files[0]} && \
       python3 tools/python/upload_python_package_to_azure_storage.py \

--- a/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_1
+++ b/tools/ci_build/github/linux/docker/Dockerfile.manylinux2014_cuda11_1
@@ -1,6 +1,6 @@
 # TODO unify this with Dockerfile.manylinux2014_cuda10_2
 
-FROM nvcr.io/nvidia/cuda:11.1-cudnn8-devel-centos7
+FROM nvcr.io/nvidia/cuda:11.1.1-cudnn8-devel-centos7
 
 #We need both CUDA and manylinux. But the CUDA Toolkit End User License Agreement says NVIDIA CUDA Driver Libraries(libcuda.so, libnvidia-ptxjitcompiler.so) are only distributable in applications that meet this criteria:
 #1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and

--- a/tools/python/upload_python_package_to_azure_storage.py
+++ b/tools/python/upload_python_package_to_azure_storage.py
@@ -4,40 +4,29 @@
 
 import os
 import argparse
-from azure.storage.blob import BlockBlobService, ContentSettings
+from azure.storage.blob import BlobServiceClient, ContentSettings
 
 
 def upload_whl(python_wheel_path, account_name, account_key, container_name):
-    block_blob_service = BlockBlobService(
-        account_name=account_name,
-        account_key=account_key
-    )
+    blob_service_client = BlobServiceClient(f"https://{account_name}.blob.core.windows.net",
+                                            credential=account_key)
+
 
     blob_name = os.path.basename(python_wheel_path)
-    block_blob_service.create_blob_from_path(container_name, blob_name, python_wheel_path)
+    blob_client = blob_service_client.get_blob_client(container_name, blob_name)
+    with open(python_wheel_path, "rb") as blob:
+        blob_client.upload_blob(blob, blob_type="BlockBlob", overwrite=True)
 
     html_blob_name = 'torch_ort_nightly.html'
-
-    download_path_to_html = "./torch_ort_nightly.html"
-    block_blob_service.get_blob_to_path(container_name, html_blob_name, download_path_to_html)
-
-    with open(download_path_to_html) as f:
-        lines = f.read().splitlines()
+    html_blob_client = blob_service_client.get_blob_client(container_name, html_blob_name)
+    lines = html_blob_client.download_blob().content_as_text().splitlines()
 
     new_line = '<a href="{blobname}">{blobname}</a><br>'.format(blobname=blob_name)
     lines.append(new_line)
     lines.sort()
-
-    with open(download_path_to_html, 'w') as f:
-        for item in lines:
-            f.write("%s\n" % item)
-
+    html_blob = "\n".join(lines)
     content_settings = ContentSettings(content_type='text/html')
-    block_blob_service.create_blob_from_path(
-        container_name,
-        html_blob_name,
-        download_path_to_html,
-        content_settings=content_settings)
+    html_blob_client.upload_blob(html_blob, blob_type="BlockBlob", content_settings=content_settings, overwrite=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
nvidia recently refreshed its signing keys (https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/), causing problems in our CI pipelines.
Some of the docker images have been updated while others have not. Moving our pipelines to use the docker images that were updated.

In addition, this PR uses the new azure APIs for uploading whl blobs to our container registry.