### PR TITLE
Use docker image 10.1 to avoid inconsistency problem

### DIFF
--- a/torch_ort/docker/Dockerfile.ort-default-stable-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
+++ b/torch_ort/docker/Dockerfile.ort-default-stable-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu102
 ARG ONNXRUNTIME_TRAINING_VERSION=1.9.0

--- a/torch_ort/docker/Dockerfile.ort-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
+++ b/torch_ort/docker/Dockerfile.ort-torch190-onnxruntime190-cu102-cudnn7-devel-ubuntu18.04
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 
 # CUDA development image for building sources
-FROM nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04 as builder
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu102
 ARG TORCH_VERSION=1.9.0


### PR DESCRIPTION
docker image `10.2` with `cudnn8` seems to have missing files leading to the error message:

`Inconsistency detected by ld.so: dl-version.c: 205: _dl_check_map_versions: Assertion needed != NULL' failed!`

in our pipelines.

While I try to figure out the root cause of the problem (which files are missing), this PR uses the `10.1` cudnn7 image as a work around.