### PR TITLE
Remove reference to unowned pypi package

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,8 +22,6 @@ python -m build
 
 ONNX Runtime for PyTorch accelerates PyTorch model training using ONNX Runtime.
 
-It is available via the torch-ort python package.
-
 This repository contains the source code for the package, as well as instructions for running the package.
 
 ## Pre-requisites


### PR DESCRIPTION
The pypi package isn't currently owned by the team that maintains this so removing the reference to reduce confusion