### PR TITLE
Update dependency versions

### DIFF
--- a/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/manylinux/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.16.6
+numpy==1.19.5
 mypy
 pytest
 setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/requirements.txt
@@ -1,5 +1,5 @@
 cerberus
-numpy==1.16.6
+numpy==1.19.5
 mypy
 pytest
 setuptools>=41.4.0

--- a/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/ortmodule/stage2/requirements.txt
@@ -5,6 +5,6 @@ transformers==v4.3.2
 tensorboard
 h5py
 wget
-pytorch-lightning==1.2.5
+pytorch-lightning==1.7.7
 deepspeed
 fairscale

--- a/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
+++ b/tools/ci_build/github/linux/docker/scripts/training/requirements.txt
@@ -2,7 +2,7 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 # transformers requires sklearn
 sklearn
-numpy==1.16.6
+numpy==1.19.5
 transformers==v2.10.0
 torch==1.6.0+cu101
 torchvision==0.7.0+cu101

--- a/torch_ort/tests/torch-ort_test_api.py
+++ b/torch_ort/tests/torch-ort_test_api.py
@@ -85,13 +85,15 @@ def test_debug_options_save_onnx_models_cwd(mode):
     _ = ort_model(x)
 
     # assert that the onnx models have been saved
+    if mode == 'training':
+        assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
+        os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
+
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
-    assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
     assert os.path.exists(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_torch_exported_{mode}.onnx"))
-    os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_pre_grad_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_optimized_{mode}.onnx"))
     os.remove(os.path.join(os.getcwd(), f"my_cwd_model_execution_model_{mode}.onnx"))
 


### PR DESCRIPTION
The existing versions of numpy and pytorch-lightning are flagged for upgrade in CI pipelines. 
Moving numpy to 1.19.5 to match other occurrences in the repo and moving pytorch-lightning to the latest version.