### PR TITLE
update sklearn to scikit-learn

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: install
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9' 
       run: |

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -13,6 +13,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: install
+      with:
+      python-version: '3.9' 
       run: |
         echo `python3 --version`
         cd torch_ort

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -12,11 +12,10 @@ jobs:
         mkdir -p /tmp/lib/python3.8/site-packages
     - name: Checkout
       uses: actions/checkout@v2
-    - name: install
-      uses: actions/checkout@v3
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9' 
+    - name: install
       run: |
         echo `python3 --version`
         cd torch_ort

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: install
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+      uses: actions/checkout@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9' 
       run: |

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
     - name: install
       with:
-      python-version: '3.9' 
+        python-version: '3.9' 
       run: |
         echo `python3 --version`
         cd torch_ort

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v2
     - name: install
       run: |
+        echo `python3 --version`
         cd torch_ort
         python3 -m pip install --upgrade protobuf==3.20.1
         python3 -m pip install --pre onnxruntime-training --no-cache-dir -f https://download.onnxruntime.ai/onnxruntime_nightly_cpu.html

--- a/torch_ort/tests/requirements-test.txt
+++ b/torch_ort/tests/requirements-test.txt
@@ -1,5 +1,5 @@
 pandas
-sklearn
+scikit-learn
 numpy==1.19.5
 transformers==v4.3.2
 tensorboard


### PR DESCRIPTION
this change is to fix the failed pipeline : pytorch_ort_packaging_nightly_aiinfra
sklearn was deprecated and should install using scikit-learn instead of sklearn.
ref : https://pypi.org/project/sklearn/

Pipeline run : https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=254825&view=logs&j=67981f12-2d9a-56a4-530f-a18d19e86536