### PR TITLE
Pin packaging to 21.3

### DIFF
--- a/torch_ort/tests/requirements-test.txt
+++ b/torch_ort/tests/requirements-test.txt
@@ -1,6 +1,7 @@
 pandas
 scikit-learn
 numpy==1.19.5
+packaging==21.3
 transformers==v4.3.2
 tensorboard
 h5py


### PR DESCRIPTION
This PR addresses nightly packaging pipeline failure by pinning the `package` version to 21.3.