### PR TITLE
upgrade torch vision

### DIFF
--- a/torch_ort/docker/Dockerfile.ort-default-stable-torch1.13.1-onnxruntime190-cu116-cudnn8-devel-ubuntu18.04
+++ b/torch_ort/docker/Dockerfile.ort-default-stable-torch1.13.1-onnxruntime190-cu116-cudnn8-devel-ubuntu18.04
@@ -7,7 +7,7 @@ FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu18.04 as builder
 ARG TORCH_CUDA_VERSION=cu116
 ARG ONNXRUNTIME_TRAINING_VERSION=1.12.0
 ARG TORCH_VERSION=1.13.1
-ARG TORCHVISION_VERSION=0.13.1
+ARG TORCHVISION_VERSION=0.14.1
 
 # Install and update tools to minimize security vulnerabilities
 RUN apt-get update

--- a/torch_ort/docker/Dockerfile.ort-torch1.13.1-onnxruntime-nightly-cu116-cudnn8-devel-ubuntu18.04
+++ b/torch_ort/docker/Dockerfile.ort-torch1.13.1-onnxruntime-nightly-cu116-cudnn8-devel-ubuntu18.04
@@ -7,7 +7,7 @@ FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu18.04 as builder
 
 ARG TORCH_CUDA_VERSION=cu116
 ARG TORCH_VERSION=1.13.1
-ARG TORCHVISION_VERSION=0.13.1
+ARG TORCHVISION_VERSION=0.14.1
 
 # Install and update tools to minimize security vulnerabilities
 RUN apt-get update


### PR DESCRIPTION
Updating torch vision to 0.14.1 to be compatible with the torch 1.13.1

Pipeline run: https://aiinfra.visualstudio.com/Lotus/_build/results?buildId=264916&view=logs&j=67981f12-2d9a-56a4-530f-a18d19e86536&t=67981f12-2d9a-56a4-530f-a18d19e86536